### PR TITLE
RW clone fix

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -26,6 +26,12 @@ else
   import_args="-o readonly=on -N"
 fi
 
+# Import pools by default in read-write mode
+if getargbool 0 read_write ; then
+  info "ZFSBootMenu: Enabling read-write ZFS pool import"
+  import_args="${import_args/readonly=on/readonly=off}"
+fi
+
 # Set a menu timeout, to allow immediate booting
 menu_timeout=$( getarg timeout=)
 if [ -n "${menu_timeout}" ]; then


### PR DESCRIPTION
By default, pools are now imported read-only. Because of this safety check, cloning a snapshot will fail. In the `clone_snapshot` function, we now do the following:

Check if the pool is read-only. If it is:
export the pool
toggle the readonly option in import_args
import the pool
if needed, reload encryption keys

The `key_wrapper` function was created to be a one-stop call to check if keys are needed for a fileystem, and to load them via file or prompt as required. This is used in a few different places now, and cleans up a bit of repeated logic.

The module argument `read_write` was added, with a default value of 0. If read_write=1 is passed on boot, pools will be imported in read-write mode. 