### PR TITLE
Core update/feature bump

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -80,6 +80,7 @@ install() {
   dracut_install /usr/bin/tail
   dracut_install /usr/lib/udev/zvol_id
   inst_simple "${moddir}/zfsbootmenu-lib.sh" "/lib/zfsbootmenu-lib.sh"
+  inst_simple "${moddir}/zfsbootmenu-preview.sh" "/bin/zfsbootmenu-preview.sh"
   inst_hook cmdline 95 "${moddir}/zfsbootmenu-parse-commandline.sh"
   inst_hook pre-mount 90 "${moddir}/zfsbootmenu.sh"
 

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -40,6 +40,10 @@ else
   menu_timeout=10
 fi
 
+if getargbool 1 die_on_import_failure ; then
+  info "ZFSBootMenu: Disabling die on import failure"
+fi
+
 wait_for_zfs=0
 case "${root}" in
   ""|zfsbootmenu|zfsbootmenu:)

--- a/90zfsbootmenu/zfsbootmenu-preview.sh
+++ b/90zfsbootmenu/zfsbootmenu-preview.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+BASE="${1}"
+ENV="${2}"
+BOOTFS="${3}"
+
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+while IFS= read -r line
+do
+  selected_kernel="${line}"
+done < "${BASE}/${ENV}/default_kernel"
+
+while IFS= read -r line
+do
+  selected_arguments="${line}"
+done < "${BASE}/${ENV}/default_args"
+
+if [[ "${BOOTFS}" =~ "${ENV}" ]]; then
+  selected_env_str="${ENV} (default) - ${selected_kernel}"
+else
+  selected_env_str="${ENV} - ${selected_kernel}"
+fi
+
+# Left pad the strings to center them based on the preview width
+selected_env_str="$( printf "%*s\n" $(( (${#selected_env_str} + FZF_PREVIEW_COLUMNS) / 2)) "${selected_env_str}" )"
+selected_arguments="$( printf "%*s\n" $(( (${#selected_arguments} + FZF_PREVIEW_COLUMNS) / 2)) "${selected_arguments}" )"
+
+echo -e "${GREEN}${selected_env_str}${NC}"
+echo "${selected_arguments}"


### PR DESCRIPTION
Instead of sequentially mounting each BE to the same mount point, sub directories of the form:

$TMP/$BE/mnt are created, where the boot environment is mounted.

Under that same directory structure, the default kernel and arguments are stored, as well as all detected kernels. These can be used by any function/tool, as they reside outside of the mountpoint.

A default bootfs option has been configured, ALT-D. This reads the selected environment and sets it as the bootfs value for the associated pool.

The main screen now has a preview window, showing the selected boot environment and the default kernel, as well as the kernel command line arguments. If the selected environment is the default bootfs, (default) is added to the preview line. 

Snapshot clones now auto-increment a 3-digit value attached to the end of the snapshot name. If you clone `zroot/ROOT/boot@initial`, it will become `zroot/ROOT/boot_initial_000`. Subsequent snapshots will becomes `zroot/ROOT/boot_initial_001` and so on. The behavior after 999 is undefined - good luck if you create 1000 clones of a snapshot.

The help/key lines at the bottom of each screen have been reduced to one line each. 

In the primary boot path, key_wrapper has been called with the correct values instead of empty/undefined values in both cases. 