### PR TITLE
Set proper file modes for configuration files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: install zfsbootmenu
 
 install: zfsbootmenu
-	install -t $(DESTDIR)/etc/zfsbootmenu/ -D etc/zfsbootmenu/config.ini
-	install -t $(DESTDIR)/etc/zfsbootmenu/dracut.conf.d/ -D etc/zfsbootmenu/dracut.conf.d/*
+	install -m 0644 -t $(DESTDIR)/etc/zfsbootmenu/ -D etc/zfsbootmenu/config.ini
+	install -m 0644 -t $(DESTDIR)/etc/zfsbootmenu/dracut.conf.d/ -D etc/zfsbootmenu/dracut.conf.d/*
 	install -m 0755 -t $(DESTDIR)/usr/lib/dracut/modules.d/90zfsbootmenu -D 90zfsbootmenu/*
 	install -m 0755 -t $(DESTDIR)$(PREFIX)/bin/ -D bin/generate-zbm


### PR DESCRIPTION
The default mode for files copied by `install` is 0755. Configuration files in /etc/zfsbootmenu are installed with this mode by default. This PR changes the mode for configuration files to 0644.