### PR TITLE
Add hot-key to accept custom commandline

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-preview.sh
+++ b/90zfsbootmenu/zfsbootmenu-preview.sh
@@ -13,10 +13,17 @@ do
   selected_kernel="${line}"
 done < "${BASE}/${ENV}/default_kernel"
 
+if [ -f "${BASE}/default_args" ]
+then
+  ARGS="${BASE}/default_args"
+else
+  ARGS="${BASE}/${ENV}/default_args"
+fi
+
 while IFS= read -r line
 do
   selected_arguments="${line}"
-done < "${BASE}/${ENV}/default_args"
+done < "${ARGS}"
 
 if [[ "${BOOTFS}" =~ "${ENV}" ]]; then
   selected_env_str="${ENV} (default) - ${selected_kernel}"
@@ -24,9 +31,16 @@ else
   selected_env_str="${ENV} - ${selected_kernel}"
 fi
 
+if [ -z ${FZF_PREVIEW_COLUMNS} ]
+then
+  WIDTH="$( tput cols )"
+else
+  WIDTH="${FZF_PREVIEW_COLUMNS}"
+fi
+
 # Left pad the strings to center them based on the preview width
-selected_env_str="$( printf "%*s\n" $(( (${#selected_env_str} + FZF_PREVIEW_COLUMNS) / 2)) "${selected_env_str}" )"
-selected_arguments="$( printf "%*s\n" $(( (${#selected_arguments} + FZF_PREVIEW_COLUMNS) / 2)) "${selected_arguments}" )"
+selected_env_str="$( printf "%*s\n" $(( (${#selected_env_str} + ${WIDTH} ) / 2)) "${selected_env_str}" )"
+selected_arguments="$( printf "%*s\n" $(( (${#selected_arguments} + ${WIDTH} ) / 2)) "${selected_arguments}" )"
 
 echo -e "${GREEN}${selected_env_str}${NC}"
 echo "${selected_arguments}"

--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -198,7 +198,7 @@ while true; do
         BE_SELECTED=0
         ;;
       "alt-s")
-        selected_snap="$( draw_snapshots ${selected_be} )"
+        selected_snap="$( draw_snapshots "${selected_be}" )"
         ret=$?
 
         if [ $ret -eq 130 ]; then
@@ -221,6 +221,33 @@ while true; do
         ;;
       "alt-r")
         emergency_shell "alt-r invoked"
+        ;;
+      "alt-c")
+        tput clear
+        tput cnorm
+
+        zfsbootmenu-preview.sh ${BASE} ${selected_be} ${BOOTFS}
+
+        if [ -f "${BASE}/default_args" ]
+        then
+          ARGS="${BASE}/default_args"
+        else
+          ARGS="${BASE}/${selected_be}/default_args"
+        fi
+
+        while IFS= read -r line
+        do
+          def_args="${line}"
+        done < "${ARGS}"
+        echo -e "\nNew kernel command line"
+        read -r -e -i "${def_args}" -p "> " cmdline
+        if [ -n "${cmdline}" ]
+        then
+          echo "${cmdline}" > "${BASE}/default_args"
+        fi
+        BE_SELECTED=0
+        tput civis
+        ;;
     esac
   fi
 done


### PR DESCRIPTION
press alt-c on the main bootmenu screen to be prompted for a custom
kernel commandline. If this file is present, it's read by the preview
header. This kernel commandline is not persisted between reboots.