### PR TITLE
Prefer ZFS property org.zfsbootmenu:commandline for command-line args

### DIFF
--- a/void-install.md
+++ b/void-install.md
@@ -128,9 +128,9 @@ xbps-reconfigure -f linux5.4
 ```
 # Install and configure ZFSBootMenu
 
-* Create /etc/default/grub . This is read by `ZFSBootMenu` to know what kernel command line arguments are needed to boot the final kernel.
+* Assign command-line arguments to be used when booting the final kernel. Because ZFS properties are inherited, assign the common properties to the `ROOT` dataset so all children will inherit common arguments by default.
 ```
-echo "GRUB_CMDLINE_LINUX_DEFAULT=\"spl_hostid=$( hostid ) ro quiet\"" > /etc/default/grub
+zfs set org.zfsbootmenu:commandline="spl_hostid=$( hostid ) ro quiet" zpool/ROOT
 ```
 
 * Create an EFI partition on `/dev/sdb`


### PR DESCRIPTION
It bothers me to have `/etc/default/grub` to define command-line arguments when I don't have grub installed. Moving the arguments to the ZFS property `org.zfsbootmenu:commandline` is consistent with the reliance on `org.zfsbootmenu:kernel` for choosing a kernel version, and allows for nice default-and-override semantics that aren't realizable with a filesystem.

This should supersede issue #23, because this seems like a cleaner approach. I only wanted command-line inheritance because I didn't want the grub file. :)