### PR TITLE
Fix infinite loop in recovery console

### DIFF
--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -221,6 +221,7 @@ while true; do
         ;;
       "alt-r")
         emergency_shell "alt-r invoked"
+        BE_SELECTED=0
         ;;
       "alt-c")
         tput clear


### PR DESCRIPTION
If `BE_SELECTED` is not cleared after entering the recovery shell, the shell will keep restarting upon exit.