### PR TITLE
zfsbootmenu.sh: set console options before showing menu

### DIFF
--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -26,6 +26,10 @@ BASE="$( mktemp -d /tmp/zfs.XXXX )"
 modprobe zfs 2>/dev/null
 udevadm settle
 
+# try to set console options for display and interaction
+# this is sometimes run as an initqueue hook, but cannot be guaranteed
+test -x /lib/udev/console_init -a -c /dev/tty0 && /lib/udev/console_init tty0
+
 # Find all pools by name that are listed as ONLINE, then import them
 response="$( find_online_pools )"
 ret=$?


### PR DESCRIPTION
Dracut provides options for handling console options (font, keymap, unicode/ASCII mode) in the `i18n` module (located in, *e.g.*, `/lib/dracut/modules.d/10i18n`). Inside the initramfs, the module installs the script `/lib/udev/console_init` to set these options according to the contents of `/etc/vconsole.conf`, which is populated by a `cmdline` hook that maps `rd.vconsole.*` kernel command-line options to values in this file (see `dracut.cmdline(7)` for more information). The module also installs a `udev` rule that will add a call to the `console_init` script as a dracut `initqueue` hook.

Unfortunately, execution of the `initqueue` hook is not guaranteed; the `initqueue` runloop continues until a number of predetermined "finish" conditions are satisfied. In `zfsbootmenu`, it seems the only finish condition is the existence of `/dev/zfs`. If this device node is available before the `initqueue` runloop has a chance to start, the `console_init` hook will never run (nor will other `initqueue` hooks). In my experience, the device node is always available before the runloop has a chance to execute, so console fonts and related paramters are never set.

Often, in a normal initramfs, this is not a problem. However, because `zfsbootmenu` often intends to interact with users, properly setting keyboard maps and fonts is a desirable feature (especially to allow selection of larger fonts on HiDPI displays).

This modification to the main `zfsbootmenu` script checks for the existence of the `console_init` script and the primary `/dev/tty0` character device and, if both are found, invokes the `console_init` script to properly configure the console. In some cases, this means the `console_init` script will be invoked twice (once by dracut and once by `zfsbootmenu`). This should not cause any issues. There does not seem to be a clean, reliable way to determine if the script was invoked by dracut.

As a result of this change, one may launch `zfsbootmenu` with the `rd.vconsole.*` parameters set on its command line, and the boot menu should be displayed with the appropriate options.

EDIT: [Upstream issue #818](https://github.com/dracutdevs/dracut/issues/818) has been opened to get the dracut people to start thinking about this. If dracut behavior changes in the future, this workaround may be made obsolete.