### PR TITLE
[WIP] Run shellcheck on any push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: ZFS Boot Menu
+on: [ push ] 
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master
+      with:
+        ignore: module-setup.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Introduction
 
+![](https://github.com/zdykstra/zfsbootmenu/workflows/ZFS%20Boot%20Menu/badge.svg)
 
 [![asciicast](https://asciinema.org/a/FN4gWtVUPPXzgZPrCjd8mK6Vz.svg)](https://asciinema.org/a/FN4gWtVUPPXzgZPrCjd8mK6Vz)
 


### PR DESCRIPTION
`shellcheck` can help catch a number of small issues, and otherwise point out minor improvements. This commit adds an Actions config to execute `shellcheck` on a push to any branch. 

`modules-setup.sh` and `zfsbootmenu-parse-commandline.sh` have a number of problems that will need to be fixed before this can be merged, so we have a passing badge!