### PR TITLE
Trap kernel module installation failure

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -20,16 +20,36 @@ depends() {
 }
 
 installkernel() {
-  instmods zfs
-  instmods zcommon
-  instmods znvpair
-  instmods zavl
-  instmods zunicode
-  instmods zlua
-  instmods icp
-  instmods spl
-  instmods zlib_deflate
-  instmods zlib_inflate
+  local mod
+
+  local required_modules=(
+    "zfs"
+    "zcommon"
+    "znvpair"
+    "zavl"
+    "zunicode"
+    "zlua"
+    "icp"
+    "spl"
+  )
+
+  for mod in "${required_modules[@]}"
+  do
+    if ! instmods -c "${mod}" ; then
+      dfatal "Required kernel module '${mod}' is missing, aborting image creation!"
+      exit 1
+    fi
+  done
+
+  local optional_modules=(
+    "zlib_deflate"
+    "zlib_inflate"
+  )
+
+  for mod in "${optional_modules[@]}"
+  do
+    instmods "${mod}"
+  done
 }
 
 install() {

--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -37,9 +37,10 @@ my ( %runConf, %config, %components );
 
 my $configfile = "/etc/zfsbootmenu/config.ini";
 
-$runConf{bootdir} = "/boot";
-$runConf{confd}   = "/etc/zfsbootmenu/dracut.conf.d";
-$runConf{version} = $VERSION;
+$runConf{bootdir}   = "/boot";
+$runConf{confd}     = "/etc/zfsbootmenu/dracut.conf.d";
+$runConf{version}   = $VERSION;
+$runConf{exit_code} = 0;
 
 GetOptions(
   "version|v=s" => \$runConf{version},
@@ -307,8 +308,12 @@ sub createInitramfs {
   if ( $status eq 0 ) {
     return $output_file;
   } else {
-    print Dumper(@output);
-    die "Failed to create $output_file";
+    foreach my $line (@output) {
+      print $line;
+    }
+    print "Failed to create $output_file\n";
+    $runConf{exit_code} = $status;
+    exit;
   }
 }
 
@@ -336,8 +341,12 @@ sub unifiedEFI {
   if ( $status eq 0 ) {
     return $output_file;
   } else {
-    print Dumper(@output);
-    die "Failed to create $output_file";
+    foreach my $line (@output) {
+      print $line;
+    }
+    print "Failed to create $output_file\n";
+    $runConf{exit_code} = $status;
+    exit;
   }
 }
 
@@ -361,4 +370,5 @@ sub cleanupMount {
     my $cmd = "umount $config{Global}{BootMountPoint}";
     execute($cmd);
   }
+  exit $runConf{exit_code};
 }


### PR DESCRIPTION
Instead of silently ignoring installation failures for critical kernel modules, we now check the return code from the install helper for key modules. If the module could not be installed, the error is trapped and an exit is forced to propagate this up to generate-zbm, which in turn exits before replacing or removing any initramfs/efi files.

Optional modules can still have installation attempts without erroring out the process.

**Broken on purpose**
```
bash-5.0# bin/generate-zbm --version test
Mounting /boot/efi
dracut-install: Failed to find module 'fake2'
dracut: FAILED:  /usr/lib/dracut/dracut-install -D /var/tmp/dracut.tJg9k4/initramfs --kerneldir /lib/modules/5.6.18_1/ -m fake2
dracut: Required kernel module 'fake2' is missing, aborting image creation!
Failed to create /tmp/HP8VWQTu83/zfsbootmenu.efi
Unmounting /boot/efi
bash-5.0# echo $?
1
```
**Working correctly**
```
bash-5.0# bin/generate-zbm --version test
Mounting /boot/efi
Found 3 existing EFI images, allowed to have a total of 3
Created a unified EFI at /boot/efi/EFI/void/vmlinuz-test_1.EFI
Unmounting /boot/efi
bash-5.0# echo $?
0
```
This will take a modification to the zfsbootmenu INSTALL helper in void-packages, as it currently blindly runs `generate-zbm` without trapping the exit code.

```
bash-5.0# xbps-reconfigure -f zfsbootmenu
zfsbootmenu: configuring ...
Mounting /boot/efi
dracut-install: Failed to find module 'fake2'
dracut: FAILED:  /usr/lib/dracut/dracut-install -D /var/tmp/dracut.Or6Mqu/initramfs --kerneldir /lib/modules/5.6.18_1/ -m fake2
dracut: Required kernel module 'fake2' is missing, aborting image creation!
Failed to create /tmp/ZuNvEkfQd2/zfsbootmenu.efi
Unmounting /boot/efi
zfsbootmenu: configured successfully.