### PR TITLE
Show diff of snapshot against the current filesystem

### DIFF
--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -233,6 +233,14 @@ while true; do
         tput clear
         tput cnorm
 
+        case "${subkey}" in
+          "alt-d")
+            draw_diff "${selected_snap}"
+            BE_SELECTED=1
+            continue
+          ;;
+        esac
+
         # Strip parent datasets
         pre_populated="${selected_snap##*/}"
         # Strip snapshot name and append NEW


### PR DESCRIPTION
When figuring out which snapshot to boot to fix a problem, it can be useful to know which files have changed. When browsing snapshots, there's now an ALT-D key handler which will call the `show_diff()` function. This function takes a single argument, the name of a snapshot. The pool and origin filesystem of the snapshot are determined via bash variable manipulation.  The diff shows all the changes between the snapshot selected and the current state of the fileystem.

To handle `zfs diff` not exiting when the `fzf` browser is exited early, the pid of the process is captured and then killed when fzf exits. The pool is mounted read-write because the `zfs diff` process requires it. 

`BE_SELECTED` is reset to 1, so that you return to the list of snapshots for that boot environmentt, instead of all the way back to the boot environment list.
