### PR TITLE
Draw the preview header on kernel, snapshot and diff screens

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -71,7 +71,9 @@ draw_kernel() {
   benv="${1}"
 
   selected="$( fzf --prompt "${benv} > " --tac --expect=alt-d \
-    --with-nth=2 --header="[ENTER] boot [ALT+D] set default [ESC] back" < "${BASE}/${benv}/kernels" )"
+    --with-nth=2 --header="[ENTER] boot [ALT+D] set default [ESC] back" \
+    --preview-window=up:2 \
+    --preview="zfsbootmenu-preview.sh ${BASE} ${benv} ${BOOTFS}" < "${BASE}/${benv}/kernels" )"
   ret=$?
   # shellcheck disable=SC2119
   csv_cat <<< "${selected}"
@@ -89,7 +91,9 @@ draw_snapshots() {
 
   selected="$( zfs list -t snapshot -H -o name "${benv}" |
     fzf --prompt "Snapshot > " --tac --expect=alt-x,alt-c,alt-d \
-        --header="[ENTER] duplicate [ALT+X] clone and promote [ALT+C] clone only [ALT+D] show diff [ESC] back" )"
+      --preview="zfsbootmenu-preview.sh ${BASE} ${benv} ${BOOTFS}" \
+      --preview-window=up:2 \
+      --header="[ENTER] duplicate [ALT+X] clone and promote [ALT+C] clone only [ALT+D] show diff [ESC] back" )"
   ret=$?
   # shellcheck disable=SC2119
   csv_cat <<< "${selected}"
@@ -124,7 +128,9 @@ draw_diff() {
   ( zfs diff -H "${snapshot}" "${diff_target}" & echo $! >&3 ) 3>/tmp/diff.pid | \
     sed "s,${mnt},," | \
     fzf --prompt "Files > " \
-    --bind 'esc:execute-silent( kill $( cat /tmp/diff.pid ) )+abort'
+      --preview="zfsbootmenu-preview.sh ${BASE} ${diff_target} ${BOOTFS}" \
+      --preview-window=up:2 \
+      --bind 'esc:execute-silent( kill $( cat /tmp/diff.pid ) )+abort'
 
   test -f /tmp/diff.pid  && rm /tmp/diff.pid
   umount "${mnt}"


### PR DESCRIPTION
This draws the two line header on all of the sub-menus. This results in a seamless transition between screens - except on the diff screen. Until the `zfs diff` process starts to output lines, `fzf` doesn't draw the preview header. 