### PR TITLE
Initial support for org.zfsbootmenu:active visibility

### DIFF
--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -597,7 +597,7 @@ key_wrapper() {
 # returns: 0 on success, 1 on failure
 
 populate_be_list() {
-  local be_list fs mnt active
+  local be_list fs mnt active candidates
 
   be_list="${1}"
   [ -n "${be_list}" ] || return 1
@@ -608,16 +608,19 @@ populate_be_list() {
   # Find valid BEs
   while IFS=$'\t' read -r fs mnt active; do
     if [ "x${mnt}" = "x/" ]; then
-      # When mountpoint=/, org.zfsbootmenu:active=off hides this BE
+      # When mountpoint=/, BE is a candidate unless org.zfsbootmenu:active=off
       [ "x${active}" = "xoff" ] && continue
     elif [ "x${mnt}" = "xlegacy" ]; then
-      # When mountpoint=legacy, org.zfsbootmenu:active=on may show this BE
+      # When mountpoint=legacy, BE is a candidate only if org.zfsbootmenu:active=on
       [ "x${active}" = "xon" ] || continue
     else
       # All other datasets are ignored
       continue
     fi
+    candidates+=( "${fs}" )
+  done <<< "$(zfs list -H -o name,mountpoint,org.zfsbootmenu:active)"
 
+  for fs in "${candidates[@]}"; do
     # Unlock if necessary
     key_wrapper "${fs}" || continue
 
@@ -626,8 +629,7 @@ populate_be_list() {
     if output="$( find_be_kernels "${fs}" )" ; then
       echo "${fs}" >> "${be_list}"
     fi
-  done <<< "$(zfs list -H -o name,mountpoint,org.zfsbootmenu:active)"
-
+  done
   return 0
 }
 

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -3,8 +3,7 @@
 # ZFS boot menu functions
 
 # arg1: ZFS filesystem name
-# arg2: mountpoint
-# prints: No output
+# prints: mountpoint
 # returns: 0 on success
 
 mount_zfs() {
@@ -15,8 +14,14 @@ mount_zfs() {
   mnt="${BASE}/${fs}/mnt"
   test -d "${mnt}" || mkdir -p "${mnt}"
 
-  mount -o zfsutil -t zfs "${fs}" "${mnt}"
-  ret=$?
+  # zfsutil is required for non-legacy mounts and omitted for legacy mounts
+  if [ "x$(zfs get -H -o value mountpoint "${fs}")" = "xlegacy" ]; then
+    mount -t zfs "${fs}" "${mnt}"
+    ret=$?
+  else
+    mount -o zfsutil -t zfs "${fs}" "${mnt}"
+    ret=$?
+  fi
 
   echo "${mnt}"
   return ${ret}
@@ -272,7 +277,6 @@ set_default_env() {
 }
 
 # arg1: ZFS filesystem
-# arg2: mountpoint
 # prints: nothing
 # returns: 0 if kernels were found, 1 otherwise
 
@@ -593,7 +597,7 @@ key_wrapper() {
 # returns: 0 on success, 1 on failure
 
 populate_be_list() {
-  local be_list
+  local be_list fs mnt active
 
   be_list="${1}"
   [ -n "${be_list}" ] || return 1
@@ -601,18 +605,28 @@ populate_be_list() {
   # Truncate the list to avoid stale entries
   : > "${be_list}"
 
-  # Find any filesystems that mount to /, see if there are any kernels present
-  for FS in $( zfs list -H -o name,mountpoint | grep -E "/$" | cut -f1 ); do
-    if ! key_wrapper "${FS}" ; then
+  # Find valid BEs
+  while IFS=$'\t' read -r fs mnt active; do
+    if [ "x${mnt}" = "x/" ]; then
+      # When mountpoint=/, org.zfsbootmenu:active=off hides this BE
+      [ "x${active}" = "xoff" ] && continue
+    elif [ "x${mnt}" = "xlegacy" ]; then
+      # When mountpoint=legacy, org.zfsbootmenu:active=on may show this BE
+      [ "x${active}" = "xon" ] || continue
+    else
+      # All other datasets are ignored
       continue
     fi
 
-    # Check for kernels under the mountpoint, add to our BE list
+    # Unlock if necessary
+    key_wrapper "${fs}" || continue
+
+    # Candidates are added to BE list if they have kernels in /boot
     # shellcheck disable=SC2034
-    if output="$( find_be_kernels "${FS}" )" ; then
-      echo "${FS}" >> "${be_list}"
+    if output="$( find_be_kernels "${fs}" )" ; then
+      echo "${fs}" >> "${be_list}"
     fi
-  done
+  done <<< "$(zfs list -H -o name,mountpoint,org.zfsbootmenu:active)"
 
   return 0
 }

--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ The following properties can be set at whatever level of the pool you'd prefer t
 
 * `org.zfsbootmenu:kernel` this can be a partial kernel name `(5.4)` or an explicit name `(vmlinuz-5.6.11_1)`.
 * `org.zfsbootmenu:commandline` set the list of kernel commandline options to be passed to the final OS. Do not set `root=`, this is set for you.
+* `org.zfsbootmenu:active` controls whether boot environments appear in or are hidden from ZFS Boot Menu:
+  - If a boot environment has the property `mountpoint=/`, set `org.zfsbootmenu:active=off` to *hide* the environment. For any other value, including not set, the boot environment will be shown.
+  - If a boot environment has the property `mountpoint=legacy`, set `org.zfsbootmenu:active=on` to *show* the environment. For any other value, including not set, the boot environment will be hidden.
 
 
 # initramfs creation


### PR DESCRIPTION
If a BE has `mountpoint=/`, setting `org.zfsbootmenu:active=off` will hide the BE from the boot menu; all other values will cause it to be shown. Conversely, if a BE has `mountpoint=legacy`, setting `org.zfsbootmenu:active=on` will cause the BE to be shown in the boot menu; all other values will prevent its display.

The idea is to allow different BEs to mount each other from `fstab`, which will not work unless `mountpoint=legacy`. This is useful, for example, if one has glibc and musl BEs and wishes to use one as a chroot from the other. The addition of `org.zfsbootmenu:active` provides a way to signal that `legacy`-mounted datasets should be scanned for kernels; otherwise we would have to scan every `legacy` dataset indiscriminately. Since I've added this property, allowing `org.zfsbootmenu:active=off` to hide BEs with `mountpoint=/` was a natural extension.

Tested and Works for Me (TM).