### PR TITLE
Fix kernel version handling for kernel with LOCALVERSION

### DIFF
--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -125,7 +125,7 @@ if ( ( defined $runConf{kernel} ) and ( length $runConf{kernel} ) ) {
 }
 
 $runConf{bootdir} = dirname( $runConf{kernel} );
-( $runConf{kernel_prefix}, $runConf{kernel_version} ) = split( '-', basename( $runConf{kernel} ) );
+( $runConf{kernel_prefix}, $runConf{kernel_version} ) = split( '-', basename( $runConf{kernel} ), 2 );
 
 # We need to create an initramfs for all cases other than unifiedEFI
 if ( defined( $config{Components}{Copies} ) and ( $config{Components}{Copies} gt 0 ) ) {


### PR DESCRIPTION
Linux patchset usually suffix its kernel version with `LOCALVERSION=-patchname` which result in a final kernel image version such as `5.6.19-xanmod1`. Since ZBM is using `split` on dash, this causes the following error when trying to generate ZBM image:

```shellsession
$ doas generate-zbm -k /boot/vmlinuz-5.6.19-xanmod1_1
Creating ZFS Boot Menu 1.2_1, with vmlinuz 5.6.19
dracut: Cannot find module directory /lib/modules/5.6.19/
dracut: and --no-kernel was not specified
Failed to create /tmp/q3IGVj5Os5/zfsbootmenu

$ ls -alh /lib/modules/
total 315K
drwxr-xr-x   6 root root    6 Jul  2 18:54 .
drwxr-xr-x 111 root root 2.1K Jul  2 18:33 ..
drwxr-xr-x   2 root root    9 Jul  2 18:32 5.4.49_1
drwxr-xr-x   4 root root   18 Jun 19 12:59 5.6.16-xanmod1_1
drwxr-xr-x   4 root root   18 Jul  2 18:55 5.6.19-xanmod1_1
drwxr-xr-x   4 root root   18 Jul  2 17:44 5.6.19_1 
```

Specifying limit of 2 allows the correct kernel module to be detected:

```shellsession
$ doas generate-zbm -k /boot/vmlinuz-5.6.19-xanmod1_1
Creating ZFS Boot Menu 1.2_1, with vmlinuz 5.6.19-xanmod1_1
Found 1 existing images, allowed to have a total of 3
Created /boot/efi/EFI/void/vmlinuz-1.2_1, /boot/efi/EFI/void/initramfs-1.2_1.img
```