### PR TITLE
Add configuration options for kernel, version and prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ Copies=0
 
 ### Kernel
 * `CommandLine` If you're making a unified EFI file, this is the command line passed to the module. Refer to [Command line options](README.md#command-line-options).
+* `Path` The full path to a specific kernel to use when making generating the boot-menu images. If not specified, `generate-zbm` will try to pick a reasonable kernel.
+* `Version` A specific kernel version to use, or use `/current` to assume the version returned by `uname -r`. If not set, `generate-zbm` will try to parse the path of the selected kernel for a version.
+* `Prefix` The prefix to use for the names of ZFS Boot Menu kernels or unified EFI images. By default, the prefix is extracted from the input kernel name.
 
 ### Components
 * `ImageDir` This is the destination directory for the initramfs and kernel.

--- a/bin/generate-zbm
+++ b/bin/generate-zbm
@@ -82,7 +82,7 @@ $runConf{version} = $runConf{version} . "_1";
 # Read our config into a hash
 tie %config, 'Config::IniFiles', ( -file => $configfile );
 
-unless ( ( defined $config{Global}{ManageImages} ) and ( $config{Global}{ManageImages} ) ) {
+unless ( ( defined $config{Global}{ManageImages} ) and $config{Global}{ManageImages} ) {
   print "ManageImages not enabled, no action taken\n";
   exit;
 }
@@ -122,6 +122,31 @@ if ( nonempty $config{Global}{BootMountPoint} ) {
 # It is automatically purged on program exit
 my $dir     = File::Temp->newdir();
 my $tempdir = $dir->dirname;
+
+# Config file may provide some default values for command-line args
+if ( nonempty $config{Kernel}{Path} and ! nonempty $runConf{kernel} ) {
+  $runConf{kernel} = $config{Kernel}{Path};
+}
+
+if ( nonempty $config{Kernel}{Prefix} and ! nonempty $runConf{kernel_prefix} ) {
+  $runConf{kernel_prefix} = $config{Kernel}{Prefix};
+}
+
+if ( nonempty $config{Kernel}{Version} and ! nonempty $runConf{kernel_version} ) {
+  $runConf{kernel_version} = $config{Kernel}{Version};
+}
+
+# Map "/current" kernel version to output of `uname r`
+if (nonempty $runConf{kernel_version} and $runConf{kernel_version} =~ /^\/current$/i) {
+  my ($uname, $status) = execute(qw(uname -r));
+  unless ( $status eq 0 ) {
+    print "Cannot determine current kernel version\n";
+    $runConf{exit_code} = $status;
+    exit;
+  }
+  chomp $uname;
+  $runConf{kernel_version} = $uname
+}
 
 if ( nonempty $runConf{kernel} ) {
   # Make sure the provided kernel file exists
@@ -329,6 +354,7 @@ END {
 # Finds specifically versioned kernel in /boot
 sub versionedKernel {
   my ($kver, ) = @_;
+
   foreach my $prefix (qw(vmlinuz linux vmlinux kernel)) {
     my $kernel = join( '-', ( $prefix, $kver ) );
     if ( -f join( '/', ( $runConf{bootdir}, $kernel ) ) ) {


### PR DESCRIPTION
Support new kernel options in the config file. Arch users, for example, should be able to add
```
[Kernel]
Path=/boot/vmlinuz-linux
Version=/current
```
and use `generate-zbm` without arguments to produce bootmenu images. Note I use `/current` instead of `current` because it's conceivable somebody may specify a Linux kernel with version string `current` and we don't want to conflict. Obviously `/current` is not a valid version name because the modules directory could not exist for that version (which means `dracut` would fail independently).