### PR TITLE
Fix job control in recovery shell

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -102,6 +102,7 @@ install() {
   dracut_install /usr/bin/tail
   dracut_install mbuffer
   dracut_install tr
+  dracut_install setsid
 
   # shellcheck disable=SC2154
   inst_simple "${moddir}/zfsbootmenu-lib.sh" "/lib/zfsbootmenu-lib.sh"

--- a/90zfsbootmenu/zfsbootmenu-lib.sh
+++ b/90zfsbootmenu/zfsbootmenu-lib.sh
@@ -800,5 +800,7 @@ emergency_shell() {
 
   echo -n "Launching emergency shell: "
   echo -e "${message}\n"
-  /bin/bash
+
+  # https://busybox.net/FAQ.html#job_control
+  setsid sh -c 'exec /bin/bash </dev/tty1 >/dev/tty1 2>&1'
 }


### PR DESCRIPTION
The original PR used the `cttyhack` module from `busybox`.  I've switched this to use `setsid` and some input/output redirection as noted from the URL @Piraty listed. This will enable this to be effectively the default on all installs, since every system should have `setsid` in the base install.