### PR TITLE
Prune everything not explicitly needed

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -79,9 +79,7 @@ install() {
   dracut_install /usr/lib/udev/vdev_id
   dracut_install /usr/lib/udev/zvol_id
   dracut_install tac
-  dracut_install awk
   dracut_install basename
-  dracut_install cut
   dracut_install head
   dracut_install kexec
   dracut_install fzf
@@ -89,17 +87,10 @@ install() {
   dracut_install sort
   dracut_install sed
   dracut_install grep
-  dracut_install xargs
-  dracut_install clear
-  dracut_install reset
-  dracut_install lsblk
-  dracut_install cut
   dracut_install tput
   dracut_install mount
-  dracut_install df
-  dracut_install ip
-  dracut_install /usr/bin/mkdir
-  dracut_install /usr/bin/tail
+  dracut_install mkdir
+  dracut_install tail
   dracut_install mbuffer
   dracut_install tr
 
@@ -121,11 +112,7 @@ install() {
   fi
 
   # Synchronize initramfs and system hostid
-  AA=$(hostid | cut -b 1,2)
-  BB=$(hostid | cut -b 3,4)
-  CC=$(hostid | cut -b 5,6)
-  DD=$(hostid | cut -b 7,8)
-
+  HOSTID="$( hostid )"
   # shellcheck disable=SC2154
-  echo -ne "\\x${DD}\\x${CC}\\x${BB}\\x${AA}" > "${initdir}/etc/hostid"
+  echo -ne "\\x${HOSTID:6:2}\\x${HOSTID:4:2}\\x${HOSTID:2:2}\\x${HOSTID:0:2}" > "${initdir}/etc/hostid"
 }

--- a/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
+++ b/90zfsbootmenu/zfsbootmenu-parse-commandline.sh
@@ -8,11 +8,7 @@
 spl_hostid=$(getarg spl_hostid=)
 if [ -n "${spl_hostid}" ] ; then
   info "ZFSBootMenu: Using hostid from command line: ${spl_hostid}"
-  AA=$(echo "${spl_hostid}" | cut -b 1,2)
-  BB=$(echo "${spl_hostid}" | cut -b 3,4)
-  CC=$(echo "${spl_hostid}" | cut -b 5,6)
-  DD=$(echo "${spl_hostid}" | cut -b 7,8)
-  echo -ne "\\x${DD}\\x${CC}\\x${BB}\\x${AA}" >/etc/hostid
+  echo -ne "\\x${spl_hostid:6:2}\\x${spl_hostid:4:2}\\x${spl_hostid:2:2}\\x${spl_hostid:0:2}" >/etc/hostid
 elif [ -f "/etc/hostid" ] ; then
   info "ZFSBootMenu: Using hostid from /etc/hostid: $(hostid)"
 else


### PR DESCRIPTION
Various binaries were added over the last year, and some were no longer needed. Those binaries that were not referenced in any file in 90zfsbootmenu were removed.

Other binaries (ip, df, etc) are not explicitly needed for the operation of the module. These should be optionally installed via a so-called 'recovery mode' configuration file.

The cut binary was only used to manipulate a hostid. Those routines were switched to bash string manipulation methods.