### PR TITLE
Add support for pool status and checkpoints

### DIFF
--- a/90zfsbootmenu/zfsbootmenu.sh
+++ b/90zfsbootmenu/zfsbootmenu.sh
@@ -233,6 +233,28 @@ while true; do
             ;;
         esac
         ;;
+      "alt-p")
+        selection="$( draw_pool_status )"
+        ret=$?
+
+        # Only continue if a selection was made
+        [ $ret -eq 0 ] || continue
+
+        # shellcheck disable=SC2162
+        IFS=, read subkey selected_pool <<< "${selection}"
+
+        case "${subkey}" in
+          "enter")
+            continue
+            ;;
+          "alt-d")
+            delete_checkpoint "${selected_pool}"
+            ;;
+          "alt-r")
+            rewind_checkpoint "${selected_pool}"
+            ;;
+        esac
+        ;;
       "alt-d")
         set_default_env "${selected_be}"
         ;;


### PR DESCRIPTION
- On the main boot menu screen, add a hook for ALT+P which shows a list
  of discovered/imported pools.

- On the pool health screen, add key shortcuts for Rewinding a
  checkpoint or Deleting a checkpoint. Since the fzf/sk header is a
  static string at the bottom of the menu, it is shown regardless of a
  pool checkpoint being present or not.

- If a checkpoint is to be deleted, use fzf to prompt the user Yes/No -
  defaulting to No. The pool is re-imported read/write and then the
  checkpoint is deleted.

- If a checkpoint is to be rewound, use fzf to prompt. The since a
  rewind operation has to take place on pool import, export the pool and
  then set the --rewind-to-checkpoint flag on the zpool import.

- set_rw_pool() does double duty - it guards against importing the pool
  if a resume image is found, and then it re-imports the pool R/W. The
  resume guard functionality was broken out into a distinct function so
  that it can be called before an alternate export/re-import process is
  used.