### PR TITLE
Support automatic "noresume" when importing pools R/W

### DIFF
--- a/90zfsbootmenu/module-setup.sh
+++ b/90zfsbootmenu/module-setup.sh
@@ -79,6 +79,7 @@ install() {
     "tr"
     "tac"
     "blkid"
+    "awk"
   )
 
   for _exec in "${essential_execs[@]}"; do


### PR DESCRIPTION
Rather than just warn the user about the need to set the "noresume" kernel argument when booting after an active suspend partition is detected and a pool is imported R/W, ZFSBootMenu now supports rewriting the kernel command line to remove any "resume=" arguments and append a "noresume". This uses `awk` to cleanly (and, it seems, correctly) handle the possibility of double-quoted strings in the argument list, which the kernel docs say are permitted. (The docs do not mention single-quoted strings, so we don't support them.) I was able to get an almost-functional implementation with nothing but `sed`, but it was not capable of properly ignoring the `resume=` argument as the quoted value of another argument, like `somearg="a b resume=/dev/sda c d"`. If we *really* don't care about such strange cases, we might be able drop `awk` and just do
```
sed -e 's/\([[:space:]]\+\|^\)resume=\([^[:space:]"]*\("[^"]*"\)*\)*[[:space:]]*/\1/g' <<<"$cmdline"
```
but, given the importance of kernel arguments, we probably want to strive for correctness here.

The prior behavior has been preserved by allowing the user to type DANGEROUS instead of the redefined NORESUME response to the resume guard prompt, just in case there is some unexpected edge case that thwarts automatic redirection and the user wants to assume responsibility for pool corruption.

The inline `awk` script needs some stress testing, but I've thrown a few challenging examples at it and haven't caught any unexpected failures.