### PR TITLE
[WIP] Enable the testing of changes in QEMU for rapid development/debugging

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,7 @@
+*.img
+*.qcow2
+*.raw
+vmlinuz*
+vmlinux*
+local.yaml
+.config

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,30 @@
+# Creating a ZFSBootMenu Test Pool for QEMU
+
+First, run (as root) `./setup.sh` to:
+1. Create a 1GB RAW image file,
+2. Attach it to the `loop0` loopback device,
+3. Create a GPT label and a ZFS pool `ztest`,
+4. Install Void base-minimal onto the pool,
+5. Configure the installation, and
+6. Set the `bootfs` property of `ztest`.
+
+The root password in the test installation will be set to `zfsbootmenu`.
+
+# Booting the Test Pool
+
+To boot the test environment, invoke `./run.sh`. This may be done as a regular
+user, but make sure your user is a member of the `kvm` group if you wish to
+leverate `KVM`.
+
+The following defaults can be set to a local default in the `.config`:
+```
+DRIVE="format=raw,file=zfsbootmenu-pool.img"
+INITRD="initramfs-bootmenu.img"
+MEMORY="2048M"
+SMP="2"
+DISPLAY="gtk"
+APPEND="loglevel=7 timeout=5 zfsbotmenu:POOL=ztest"
+```
+
+The ZFSBootMenu kernel command line (specified in the `APPEND` variable) can be
+overridden per run by passing an optional `-a` argument to `./run.sh`.

--- a/tests/chroot.sh
+++ b/tests/chroot.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+cat << EOF >> /etc/rc.conf
+KEYMAP="us"
+TIMEZONE="America/Chicago"
+HARDWARECLOCK="UTC"
+EOF
+
+cat << EOF >> /etc/default/libc-locales
+en_US.UTF-8 UTF-8
+en_US ISO-8859-1
+EOF
+xbps-reconfigure -f glibc-locales
+
+xbps-install -S
+xbps-install -y linux5.8 zfs
+
+#zpool set cachefile=/etc/zfs/zpool.cache ztest
+
+cat << EOF > /etc/dracut.conf.d/zol.conf
+nofsck="yes"
+add_dracutmodules+=" zfs "
+omit_dracutmodules+=" btrfs "
+EOF
+
+xbps-reconfigure -f linux5.8
+
+zfs set org.zfsbootmenu:commandline="spl_hostid=$( hostid ) ro quiet" ztest/ROOT
+
+echo 'root:zfsbootmenu' | chpasswd -c SHA256

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Setup a local config file
+if [ ! -f local.yaml ]; then 
+  cp ../etc/zfsbootmenu/config.yaml local.yaml
+  yq-go w -i local.yaml Components.ImageDir "$( pwd )"
+  yq-go w -i local.yaml Components.Versions false
+  yq-go w -i local.yaml Global.ManageImages true 
+  yq-go d -i local.yaml Global.BootMountPoint
+fi
+
+# Support x86_64 and ppc64(le)
+case "$(uname -m)" in
+  ppc64*)
+    BIN="qemu-system-ppc64"
+    KERNEL="vmlinux-bootmenu"
+    MACHINE="pseries,accel=kvm,kvm-type=HV,cap-hpt-max-page-size=4096"
+  ;;
+  x86_64)
+    BIN="qemu-system-x86_64"
+    KERNEL="vmlinuz-bootmenu"
+    MACHINE="type=q35,accel=kvm"
+  ;;
+esac
+
+DRIVE="format=raw,file=zfsbootmenu-pool.img"
+INITRD="initramfs-bootmenu.img"
+MEMORY="2048M"
+SMP="2"
+DISPLAY="gtk"
+APPEND="loglevel=7 timeout=5 zfsbotmenu:POOL=ztest"
+
+# Override any default variables
+#shellcheck disable=SC1091
+[ -f .config ] && source .config
+
+while getopts "a:" opt; do
+  case "${opt}" in
+    a)
+      APPEND="${OPTARG}"
+      ;;
+    *)
+      ;;
+  esac
+done
+
+# Purge kernel/initramfs from the previous run
+[ -f "${KERNEL}" ] && rm "${KERNEL}"
+[ -f "${INITRD}" ] && rm "${INITRD}"
+
+# Generate a new initramfs
+../bin/generate-zbm -c local.yaml
+
+# Boot it up
+"${BIN}" \
+	-kernel "${KERNEL}" \
+	-initrd "${INITRD}" \
+	-drive "${DRIVE}" \
+	-m "${MEMORY}" \
+	-smp "${SMP}" \
+	-cpu host \
+	-machine "${MACHINE}" \
+	-object rng-random,id=rng0,filename=/dev/urandom \
+	-device virtio-rng-pci,rng=rng0 \
+	-display "${DISPLAY}" \
+	-append "${APPEND}"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+MNT="$( mktemp -d )"
+
+qemu-img create zfsbootmenu-pool.img 1G
+losetup /dev/loop0 zfsbootmenu-pool.img
+kpartx -u /dev/loop0
+echo 'label: gpt' | sfdisk /dev/loop0
+zpool create -f \
+ -O compression=lz4 \
+ -O acltype=posixacl \
+ -O xattr=sa \
+ -O relatime=on \
+ -o autotrim=on \
+ -m none ztest /dev/loop0
+
+zfs create -o mountpoint=none ztest/ROOT
+zfs create -o mountpoint=/ -o canmount=noauto ztest/ROOT/void
+zfs set org.zfsbootmenu:commandline="spl_hostid=$( hostid ) ro quiet" ztest/ROOT
+zpool set bootfs=ztest/ROOT/void ztest
+
+zpool export ztest
+zpool import -R "${MNT}" ztest
+zfs mount ztest/ROOT/void
+
+case "$(uname -m)" in
+  ppc64le)
+    URL="https://mirrors.servercentral.com/void-ppc/current"
+    ;;
+  x86_64)
+    URL="https://mirrors.servercentral.com/voidlinux/current"
+    ;;
+esac
+
+# https://github.com/project-trident/trident-installer/blob/master/src-sh/void-install-zfs.sh#L541
+mkdir -p "${MNT}/var/db/xbps/keys"
+cp /var/db/xbps/keys/*.plist "${MNT}/var/db/xbps/keys/."
+
+mkdir -p "${MNT}/etc/xbps.d"
+cp /etc/xbps.d/*.conf "${MNT}/etc/xbps.d/."
+
+xbps-install -y -S -r "${MNT}" --repository="${URL}"
+
+# /etc/runit/core-services/03-console-setup.sh depends on loadkeys from kbd
+# /etc/runit/core-services/05-misc.sh depends on ip from iproute2
+xbps-install -y -r "${MNT}" --repository="${URL}" \
+  base-minimal dracut ncurses-base kbd iproute2
+
+cp /etc/hostid "${MNT}/etc/"
+cp /etc/resolv.conf "${MNT}/etc/" 
+
+mount -t proc proc "${MNT}/proc"
+mount -t sysfs sys "${MNT}/sys"
+mount -B /dev "${MNT}/dev"
+mount -t devpts pts "${MNT}/dev/pts"
+
+cp chroot.sh "${MNT}/root"
+chroot "${MNT}" /root/chroot.sh
+
+umount -R "${MNT}" && rmdir "${MNT}"
+
+zpool export ztest
+losetup -d /dev/loop0
+
+chown "$( stat -c %U . ):$( stat -c %G . )" zfsbootmenu-pool.img


### PR DESCRIPTION
* `sudo ./setup.sh`
1.  Creates a 1GB RAW image file
2.  Attaches it to the `loop0` loopback device
3. Creates a GPT label, and a ZFS pool named `ztest`
4. Installs Void base-minimal onto the pool
5. Configures the OS, sets the bootfs, and sets the root password to `zfsbootmenu`

* `./run.sh`
The following defaults can be set to a local default in `.config`:

```
DRIVE="format=raw,file=zfsbootmenu-pool.img"
INITRD="initramfs-bootmenu.img"
MEMORY="2048M"
SMP="2"
DISPLAY="gtk"
APPEND="loglevel=7 timeout=5 zfsbotmenu:POOL=ztest"
```

`run.sh` optionally takes a `-a` argument to override the kernel command line for ZFSBootMenu (`APPEND`). 