### PR TITLE
Mention that Arch+Dractut needs org.zfsbootmenu:rootprefix property set

### DIFF
--- a/man/zfsbootmenu.7
+++ b/man/zfsbootmenu.7
@@ -256,6 +256,8 @@ This specifies the prefix added to the \s-1ZFS\s0 filesystem provided as the roo
 .Sp
 The default prefix is \fIroot=zfs:\fR on all systems except those that appear to be Arch Linux. For Arch, the default root prefix is \fIzfs=\fR.
 .Sp
+\&\fBNote:\fR If you are using Arch with Dracut instead of the default mkinitcpio you will need to set \fBorg.zfsbootmenu:rootprefix=root=zfs:\fR for your system to boot.
+.Sp
 Set this property to override the value determined from inspecting the boot environment.
 .IP "\fBorg.zfsbootmenu:keysource=<filesystem>\fR" 4
 .IX Item "org.zfsbootmenu:keysource=<filesystem>"

--- a/pod/zfsbootmenu.7.pod
+++ b/pod/zfsbootmenu.7.pod
@@ -156,6 +156,8 @@ This specifies the prefix added to the ZFS filesystem provided as the root files
 
 The default prefix is I<root=zfs:> on all systems except those that appear to be Arch Linux. For Arch, the default root prefix is I<zfs=>.
 
+B<Note:> If you are using Arch with Dracut instead of the default mkinitcpio you will need to set B<org.zfsbootmenu:rootprefix=root=zfs:> for your system to boot.
+
 Set this property to override the value determined from inspecting the boot environment.
 
 =item B<org.zfsbootmenu:keysource=E<lt>filesystemE<gt>>


### PR DESCRIPTION
Closes #179